### PR TITLE
Fix Package-Requires line, update Carton

### DIFF
--- a/Carton
+++ b/Carton
@@ -1,11 +1,7 @@
 (source "melpa" "http://melpa.milkbox.net/packages/")
 (source "marmalade" "http://marmalade-repo.org/packages/")
 
-(package "helm-rails" "0.1.0" "Helm extension for rails")
-
-(depends-on "helm")
-(depends-on "magit")
-(depends-on "inflections")
+(package-file "helm-rails.el"
 
 (development
  (depends-on "ert")

--- a/helm-rails.el
+++ b/helm-rails.el
@@ -6,7 +6,7 @@
 ;; URL:               https://github.com/asok/helm-rails
 ;; Version:           0.1
 ;; Keywords:          helm, rails, git
-;; Package-Requires:  ((helm magit inflections))
+;; Package-Requires:  ((helm "1.5.1") (magit "1.2.0") (inflections "1.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
(Background: I'm working on adding this to MELPA.)

The existing `Package-Requires` header line was not package.el-compliant, and rendered the file unparseable by the `package-buffer-info` function. This commit fixes the line, and additionally modifies the Carton file to use the new "package-file" directive: using this directive, Carton will read the package dependencies and version number from the .el file just like package.el, meaning that changes need only be made in one place.

BTW, what's the deal with the "loaddefs" file? It looks like it should be generated from appropriate `;;;###autoload` code in the main .el file... 

-Steve
